### PR TITLE
Updated Semaphore lock

### DIFF
--- a/008-processinfo-binarylocation/processlibrary.h
+++ b/008-processinfo-binarylocation/processlibrary.h
@@ -105,7 +105,8 @@ static inline int print_task_binary_name(struct task_struct *tsk) {
 	if(NULL != tsk->mm) {
 
 		// hold memory map semaphore with read bias 
-		down_read(&tsk->mm->mmap_sem);
+		// mmap_sem has now been renamed to mmap_lock in recent versions of the kernel
+		down_read(&tsk->mm->mmap_lock);
 
 		if(NULL != tsk->mm->exe_file) {
 	
@@ -128,7 +129,7 @@ static inline int print_task_binary_name(struct task_struct *tsk) {
 		}
 
 		// release memory map semaphore 
-		up_read(&tsk->mm->mmap_sem);
+		up_read(&tsk->mm->mmap_lock);
 		
 	}else{
 		pr_info("target_process->mm is NULL - Kernel thread?\n");


### PR DESCRIPTION
Current output of `make` :
```
whokilleddb@uwu:~/LKMs/07-BinaryName$ KERNEL_ROOT=/home/whokilleddb/Linux/linux-5.11.0 make
make[1]: Entering directory '/home/whokilleddb/Linux/linux-5.11.0'
  CC [M]  /home/whokilleddb/LKMs/07-BinaryName/binarypath.o
In file included from /home/whokilleddb/LKMs/07-BinaryName/binarypath.c:5:
/home/whokilleddb/LKMs/07-BinaryName/process-thread-info.h: In function ‘PRINT_TASK_BINARY_NAME’:
/home/whokilleddb/LKMs/07-BinaryName/process-thread-info.h:51:29: error: ‘struct mm_struct’ has no member named ‘mmap_sem’; did you mean ‘mmap_base’?
   51 |         down_read(&tsk->mm->mmap_sem); // Lock the semaphore for reading
      |                             ^~~~~~~~
      |                             mmap_base
/home/whokilleddb/LKMs/07-BinaryName/process-thread-info.h:64:27: error: ‘struct mm_struct’ has no member named ‘mmap_sem’; did you mean ‘mmap_base’?
   64 |         up_read(&tsk->mm->mmap_sem);
      |                           ^~~~~~~~
      |                           mmap_base
make[2]: *** [scripts/Makefile.build:287: /home/whokilleddb/LKMs/07-BinaryName/binarypath.o] Error 1
make[1]: *** [Makefile:1848: /home/whokilleddb/LKMs/07-BinaryName] Error 2
make[1]: Leaving directory '/home/whokilleddb/Linux/linux-5.11.0'
```

After fixing :
```
make[1]: Entering directory '/home/whokilleddb/Linux/linux-5.11.0'
  CC [M]  /home/whokilleddb/LKMs/07-BinaryName/binarypath.o
  MODPOST /home/whokilleddb/LKMs/07-BinaryName/Module.symvers
  CC [M]  /home/whokilleddb/LKMs/07-BinaryName/binarypath.mod.o
  LD [M]  /home/whokilleddb/LKMs/07-BinaryName/binarypath.ko
  BTF [M] /home/whokilleddb/LKMs/07-BinaryName/binarypath.ko
make[1]: Leaving directory '/home/whokilleddb/Linux/linux-5.11.0'
```